### PR TITLE
Yank chef 11.4.4 in favour of chef 11.4.0

### DIFF
--- a/bootstrap/gentoo.sh
+++ b/bootstrap/gentoo.sh
@@ -11,7 +11,7 @@ else
   emerge -uDN ruby:1.9
   revdep-rebuild
 
-  gem install chef ruby-shadow --no-ri --no-rdoc
+  gem install chef ruby-shadow --no-ri --no-rdoc --version "=11.4.0"
 
   # Make non-interactive SSH sessions see environment variables
   if [[ ! `which chef-solo` ]]; then

--- a/bootstrap/redhat.sh
+++ b/bootstrap/redhat.sh
@@ -11,5 +11,5 @@ else
   tar zxf rubygems-1.8.10.tgz
   cd rubygems-1.8.10
   ruby setup.rb --no-format-executable
-  gem install chef --no-ri --no-rdoc
+  gem install chef --no-ri --no-rdoc --version "=11.4.0"
 fi

--- a/bootstrap/ubuntu.sh
+++ b/bootstrap/ubuntu.sh
@@ -4,5 +4,5 @@ if type -p chef-solo > /dev/null; then
   echo "Using chef-solo at `which chef-solo`"
 else
   apt-get install -y ruby ruby-dev libopenssl-ruby rdoc ri irb build-essential wget ssl-cert curl rubygems
-  gem install chef --no-ri --no-rdoc
+  gem install chef --no-ri --no-rdoc --version "=11.4.0"
 fi


### PR DESCRIPTION
ie. because of this bug:

  http://tickets.opscode.com/browse/CHEF-4123

ie. until opscode bother to release this change:

  https://github.com/opscode/chef/commit/451b7fb16fbc36b8a6391fec54474fc7d26f160c

Also, strange opscode haven't yanked the gem themselves:

  http://rubygems.org/gems/chef/versions/11.4.4
