### PR TITLE
bugfix: centos dns resolution issues because of natdns proxy.

### DIFF
--- a/lib/gusteau/vagrant.rb
+++ b/lib/gusteau/vagrant.rb
@@ -40,8 +40,7 @@ module Gusteau
           vb.customize ['modifyvm', :id,
             '--memory', config[:memory],
             '--name',   config[:label],
-            '--cpus',   config[:cpus],
-            '--natdnsproxy1', 'on'
+            '--cpus',   config[:cpus]
           ]
         end
         instance.vm.network :private_network, :ip => config[:ip]


### PR DESCRIPTION
Gusteau is currently forcing natdnsproxy on. 

This is causing [5 second dns resolution on Centos](https://github.com/mitchellh/vagrant/issues/1172). There is more info on auto_nat_dns_proxy virtualbox setting [here](https://github.com/mitchellh/vagrant/issues/1313).

e.g. The following has no effect:

```
# Vagrantfile
config.vm.provider :virtualbox do |vb|
  vb.customize ["modifyvm", :id, "--natdnsproxy1",        "off"]
end
```
