### PR TITLE
Fresh chef solo environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Bugfix: run chef-solo without `GEM_HOME` `GEM_PATH`
+
 ## 1.1.1 / 2013-07-14
 * Bugfix: environment attributes got altered by node ones
 

--- a/lib/gusteau/chef.rb
+++ b/lib/gusteau/chef.rb
@@ -16,7 +16,7 @@ module Gusteau
 
       @server.run "sh /etc/chef/bootstrap.sh" if opts['bootstrap']
 
-      cmd  = "chef-solo -c #{@dest_dir}/solo.rb -j #{@dest_dir}/dna.json --color"
+      cmd  = "unset GEM_HOME; unset GEM_PATH; chef-solo -c #{@dest_dir}/solo.rb -j #{@dest_dir}/dna.json --color"
       cmd << " -F #{opts['format']}"    if opts['format']
       cmd << " -l #{opts['log_level']}" if opts['log_level']
       cmd << " -W"                      if opts['why-run']


### PR DESCRIPTION
ie. a fix for gusteau not being able to use chef-solo on an existing VM.

ie. a fix for:

```
*** [2013-07-12T14:40:13] GUSTEAU: 192.168.100.30> chef-solo -c /etc/chef/solo.rb -j /etc/chef/dna.json --color
/opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/dependency.rb:247:in `to_specs': Could not find chef (>= 0) amongst [activesupport-4.0.0, atomic-1.1.10, bundler-1.3.5, bundler-unload-1.0.1, chronic-0.9.1, god-0.13.2, i18n-0.6.4, kgio-2.8.0, minitest-4.7.5, multi_json-1.7.7, rack-1.5.2, raindrops-0.11.0, rake-10.1.0, rubygems-bundler-1.2.2, rvm-1.11.3.8, thread_safe-0.1.0, tzinfo-0.3.37, unicorn-4.6.3, whenever-0.8.3] (Gem::LoadError)
    from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/dependency.rb:256:in `to_spec'
    from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems.rb:1231:in `gem'
    from /usr/bin/chef-solo:22:in `<main>'
ERROR: [2013-07-12T14:40:13] GUSTEAU:   192.168.100.30> chef-solo -c /etc/chef/solo.rb -j /etc/chef/dna.json --color
```
