### PR TITLE
#28 - adds 'box' configuration option for vagrant VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ end
 ```
 
 * The `prefix` option lets you prepend your VirtualBox VMs names, e.g. `loco-nodename`.
-* The `defaults` one lets you provide default values for `cpus`, `memory`, `box_url`.
+* The `defaults` one lets you provide default values for `cpus`, `memory`, `box_url`, `box`.
 
 Please note that the add-on only works with Vagrant ~> 1.2 and needs gusteau to be installed as a Vagrant plugin:
 

--- a/lib/gusteau/vagrant.rb
+++ b/lib/gusteau/vagrant.rb
@@ -40,9 +40,14 @@ module Gusteau
         defaults[:box_url]
       end
 
+      # If no one set the VirtualBox box name explicitly, use the end of the box_url
+      # as the box name
+      box_name = config.fetch('box', defaults[:box] || box_url.sub(/.*\/([^\/]+).box$/,'\1'))
+
       {
         :name    => node.name,
         :label   => label,
+        :box     => box_name,
         :box_url => box_url,
         :ip      => config['IP']     || defaults[:ip],
         :cpus    => config['cpus']   || defaults[:cpus]   || 1,
@@ -54,7 +59,7 @@ module Gusteau
       vm_config = vm_config(node, options)
 
       config.vm.define vm_config[:name] do |instance|
-        instance.vm.box     = vm_config[:name]
+        instance.vm.box     = vm_config[:box]
         instance.vm.box_url = vm_config[:box_url]
 
         instance.vm.provider :virtualbox do |vb|

--- a/spec/lib/gusteau/vagrant_spec.rb
+++ b/spec/lib/gusteau/vagrant_spec.rb
@@ -21,7 +21,7 @@ describe Gusteau::Vagrant do
     end
 
     it "should define vm instances with correct settings" do
-      subvm.expects('box='.to_sym).with('development-playground')
+      subvm.expects('box='.to_sym).with('b')
       subvm.expects('box_url='.to_sym).with("http://a.com/b.box")
       subvm.expects(:network).with(:private_network, { :ip => '192.168.100.21' })
       subvm.expects(:provision).never
@@ -71,6 +71,7 @@ describe Gusteau::Vagrant do
         {
           :name    => 'development-playground',
           :label   => expected_label,
+          :box     => 'centos-6.4',
           :box_url => 'https://opscode.s3.amazonaws.com/centos-6.4.box',
           :ip      => '192.168.100.21',
           :cpus    => 2,
@@ -96,6 +97,31 @@ describe Gusteau::Vagrant do
 
         it "should raise an exception" do
           proc { subject }.must_raise RuntimeError
+        end
+      end
+
+      context "box specified" do
+        let(:defaults) do
+          {
+            :box     => 'custom_box_name',
+            :box_url => 'https://opscode.s3.amazonaws.com/centos-6.4.box'
+          }
+        end
+
+        it "should use default attribute" do
+          subject[:box].must_equal "custom_box_name"
+        end
+
+        context "as node attribute" do
+          let(:node) do
+            Gusteau::Config.nodes['development-playground'].tap do |node|
+              node.config['server']['vagrant']['box'] = 'another_box_name'
+            end
+          end
+
+          it "should use node attribute" do
+            subject[:box].must_equal 'another_box_name'
+          end
         end
       end
     end


### PR DESCRIPTION
Changes `vm.box` to be a generic name so that multiple vagrant nodes can share the same basebox. `box` value resolution is as follows:
- `box` from the node's `vagrant` configuration hash
- `box` from the default vagrant configuration
- the tail of the box_url (e.g. `centos-6.4` if box_url is `https://opscode.s3.amazonaws.com/centos-6.4.box`)
