### PR TITLE
Add ability to configure the version of Chef which will be bootstrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,18 @@ You can also override `run_list` for specific nodes.
 
 ### Bootstrap script
 
-By default, Gusteau installs the [Omnibus Chef](http://www.opscode.com/chef/install/). However if you're targetting an unsupported platform you might want to specify the `platform` value for a node: this invokes a specific [script](https://github.com/locomote/gusteau/tree/master/bootstrap).
+By default, Gusteau installs the [Omnibus Chef](http://www.opscode.com/chef/install/). However if you're targeting an unsupported platform you might want to specify the `platform` value for a node: this invokes a specific [script](https://github.com/locomote/gusteau/tree/master/bootstrap).
 
 Alternatively, you can specify a custom script in `.gusteau.yml`:
 
 ```
 bootstrap: ./scripts/freebsd.sh
+```
+
+Note that the Chef version number will be passed as the first argument to the bootstrap script. You can set this version explicitly by specifying it in `.gusteau.yml`:
+
+```
+chef_version: 10.26.0
 ```
 
 ### Custom cookbooks path

--- a/bootstrap/omnibus.sh
+++ b/bootstrap/omnibus.sh
@@ -1,15 +1,19 @@
 #!/bin/sh
+# Usage: omnibus.sh VERSION - installs the requested version of Chef, skipping if it's already installed
 
 install_sh="https://www.opscode.com/chef/install.sh"
-version="11.4.4"
+requested_version=$1
 
 if type -p chef-solo > /dev/null; then
-  echo "Using chef-solo $(chef-solo --v | awk '{print $2}') at $(which chef-solo)"
+  installed_version=$(chef-solo --v | awk '{print $2}')
+fi
+if [ $installed_version == $requested_version ]; then
+  echo "Using chef-solo $installed_version at $(which chef-solo)"
 else
   if command -v curl &>/dev/null; then
-    curl -L "$install_sh" | sudo bash -s -- -v "$version"
+    curl -L "$install_sh" | sudo bash -s -- -v "$requested_version"
   elif command -v wget &>/dev/null; then
-    wget -qO- "$install_sh" | sudo bash -s -- -v "$version"
+    wget -qO- "$install_sh" | sudo bash -s -- -v "$requested_version"
   else
     echo "Neither wget nor curl found. Please install one." >&2
     exit 1

--- a/lib/gusteau/chef.rb
+++ b/lib/gusteau/chef.rb
@@ -14,7 +14,7 @@ module Gusteau
         @server.upload [dir], @dest_dir, :exclude => '.git/', :strip_c => 2
       end
 
-      @server.run "sh /etc/chef/bootstrap.sh" if opts['bootstrap']
+      @server.run "sh /etc/chef/bootstrap.sh #{Gusteau::Config.settings['chef_version']}" if opts['bootstrap']
 
       cmd  = "unset GEM_HOME; unset GEM_PATH; chef-solo -c #{@dest_dir}/solo.rb -j #{@dest_dir}/dna.json --color"
       cmd << " -F #{opts['format']}"    if opts['format']

--- a/lib/gusteau/config.rb
+++ b/lib/gusteau/config.rb
@@ -3,6 +3,7 @@ require 'gusteau/helpers'
 
 module Gusteau
   class Config
+    DEFAULT_CHEF_VERSION = '11.4.4'
     include Gusteau::ERB
 
     def self.read(config_path)
@@ -45,7 +46,8 @@ module Gusteau
       {
         'cookbooks_path' => @config['cookbooks_path'] || ['cookbooks', 'site-cookbooks'],
         'roles_path'     => @config['roles_path'] || 'roles',
-        'bootstrap'      => @config['bootstrap']
+        'bootstrap'      => @config['bootstrap'],
+        'chef_version'   => @config['chef_version'] || DEFAULT_CHEF_VERSION
       }
     end
 

--- a/spec/config/emile.yml
+++ b/spec/config/emile.yml
@@ -5,3 +5,5 @@ cookbooks_path:
 roles_path: basic-roles
 
 bootstrap: ./bootstrap/osx.sh
+
+chef_version: 10.26.0

--- a/spec/lib/gusteau/chef_spec.rb
+++ b/spec/lib/gusteau/chef_spec.rb
@@ -31,7 +31,7 @@ describe Gusteau::Chef do
       let(:bootstrap) { true }
 
       it "should run the bootstrap script and chef solo" do
-        server.expects(:run).with('sh /etc/chef/bootstrap.sh')
+        server.expects(:run).with('sh /etc/chef/bootstrap.sh 10.26.0')
         expects_run_chef_solo
         chef.run({ :path => '/tmp/node.json' }, opts)
       end

--- a/spec/lib/gusteau/config_spec.rb
+++ b/spec/lib/gusteau/config_spec.rb
@@ -41,18 +41,20 @@ describe Gusteau::Config do
     describe "#settings" do
       let(:settings) { Gusteau::Config.settings }
 
-      it "should have defaults for cookbooks_path, roles_path, bootstrap" do
+      it "should have defaults for cookbooks_path, roles_path, bootstrap, chef_version" do
         settings['cookbooks_path'].must_equal ['cookbooks', 'site-cookbooks']
         settings['roles_path'].must_equal 'roles'
         settings['bootstrap'].must_equal nil
+        settings['chef_version'].must_equal Gusteau::Config::DEFAULT_CHEF_VERSION
       end
 
       context "settings defined in the config yml" do
         before { Gusteau::Config.read("./spec/config/emile.yml") }
 
-        it "should have defaults for cookbooks_path, roles_path" do
+        it "should have defaults for cookbooks_path, roles_path, chef_version" do
           settings['cookbooks_path'].must_equal ['private-cookbooks', '/home/user/.cookbooks']
           settings['roles_path'].must_equal 'basic-roles'
+          settings['chef_version'].must_equal '10.26.0'
         end
       end
     end


### PR DESCRIPTION
Since there can be differences between Chef versions, I think people might find it useful to peg their bootstrapped Chef installations to a consistent version of Chef.

Note that the gentoo.sh script has not been updated, since I'm not familiar enough with Gentoo to be able to make it work, much less test it :)
