### PR TITLE
Pass active node name into ENV for hook commands

### DIFF
--- a/lib/gusteau/node.rb
+++ b/lib/gusteau/node.rb
@@ -40,7 +40,7 @@ module Gusteau
 
     def hook(hook_type)
       (@config[hook_type] || []).each do |cmd|
-        Kernel.system cmd
+        Kernel.system({ 'GUSTEAU_NODE' => name }, cmd)
         unless $?.exitstatus == 0
           log_error "Error executing a #{hook_type} hook: '#{cmd}'"
           exit 1

--- a/spec/lib/gusteau/node_spec.rb
+++ b/spec/lib/gusteau/node_spec.rb
@@ -67,8 +67,8 @@ describe Gusteau::Node do
 
   describe "#hook" do
     it "should execute system commands" do
-      Kernel.expects(:system).with('bundle')
-      Kernel.expects(:system).with('vagrant up')
+      Kernel.expects(:system).with({'GUSTEAU_NODE' => 'test'}, 'bundle')
+      Kernel.expects(:system).with({'GUSTEAU_NODE' => 'test'}, 'vagrant up')
       node.server.chef.expects(:run)
       node.apply([], {})
     end


### PR DESCRIPTION
Have been using Gusteau quite a bit and enjoying it, but the default `after` hook bugged me. I tend not to have all my VMs running unless I need them, so my rspec hook would always fill up with false negatives.

This PR allows you to do the following:

``` YAML
after:
  - bundle exec rspec spec/$GUSTEAU_NODE
```

and have only the relevant tests for the node you just converged/applied run.
