### PR TITLE
Fixed omnibus.sh shebang line, now uses /bin/bash

### DIFF
--- a/bootstrap/omnibus.sh
+++ b/bootstrap/omnibus.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Usage: omnibus.sh VERSION - installs the requested version of Chef, skipping if it's already installed
 
 install_sh="https://www.opscode.com/chef/install.sh"


### PR DESCRIPTION
Otherwise fails with error "curl: not found"

```
sh /etc/chef/bootstrap.sh 11.6.2
#    /etc/chef/bootstrap.sh: 10: [: ==: unexpected operator
#    /etc/chef/bootstrap.sh: 14: /etc/chef/bootstrap.sh: curl: not found

bash /etc/chef/bootstrap.sh 11.6.2
#    Using chef-solo 11.6.2 at /usr/bin/chef-solo
```
