### PR TITLE
Make dna_path cross platform

### DIFF
--- a/lib/gusteau/node.rb
+++ b/lib/gusteau/node.rb
@@ -1,4 +1,5 @@
 require 'gusteau/server'
+require 'tmpdir'
 
 module Gusteau
   class Node
@@ -11,7 +12,7 @@ module Gusteau
       @config = node_config
 
       @server = Server.new(@config['server'])
-      @dna_path = '/tmp/dna.json'
+      @dna_path = "#{Dir::tmpdir}/dna.json"
     end
 
     def converge(opts = {})


### PR DESCRIPTION
`/tmp/dna.json` is not a valid path on Windows.

It fails with:

```
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/gusteau-1.2.0/lib/gusteau/node.rb:60:in `initialize': No such file or
directory - /tmp/dna.json (Errno::ENOENT)
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/gusteau-1.2.0/lib/gusteau/node.rb:60:in `open'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/gusteau-1.2.0/lib/gusteau/node.rb:60:in `dna'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/gusteau-1.2.0/lib/gusteau/node.rb:19:in `block in converge'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/gusteau-1.2.0/lib/gusteau/node.rb:37:in `with_hooks'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/gusteau-1.2.0/lib/gusteau/node.rb:18:in `converge'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/gusteau-1.2.0/bin/gusteau:19:in `converge'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/optitron-0.3.3/lib/optitron/class_dsl.rb:112:in `dispatch'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/gusteau-1.2.0/bin/gusteau:74:in `<top (required)>'
        from C:/opscode/chef/embedded/bin/gusteau:23:in `load'
        from C:/opscode/chef/embedded/bin/gusteau:23:in `<main>'
```
