### PR TITLE
Fixes #45: use chef_config_dir on chef bootstrap

### DIFF
--- a/lib/gusteau/chef.rb
+++ b/lib/gusteau/chef.rb
@@ -17,7 +17,7 @@ module Gusteau
         @server.upload [dir], dest_dir, :exclude => '.git/', :strip_c => 2
       end
 
-      @server.run "sh /etc/chef/bootstrap.sh #{Gusteau::Config.settings['chef_version']}" if opts['bootstrap']
+      @server.run "sh #{dest_dir}/bootstrap.sh #{Gusteau::Config.settings['chef_version']}" if opts['bootstrap']
 
       cmd  = "unset GEM_HOME; unset GEM_PATH; chef-solo -c #{dest_dir}/solo.rb -j #{dest_dir}/dna.json --color"
       cmd << " -F #{opts['format']}"    if opts['format']

--- a/spec/lib/gusteau/chef_spec.rb
+++ b/spec/lib/gusteau/chef_spec.rb
@@ -31,7 +31,7 @@ describe Gusteau::Chef do
       let(:bootstrap) { true }
 
       it "should run the bootstrap script and chef solo" do
-        server.expects(:run).with('sh /etc/chef/bootstrap.sh 10.26.0')
+        server.expects(:run).with('sh /etc/custom_chef_dir/bootstrap.sh 10.26.0')
         expects_run_chef_solo
         chef.run({ :path => '/tmp/node.json' }, opts)
       end


### PR DESCRIPTION
Take chef_config_dir into account during bootsrap

Fixes the chef bootstrap spec
