### PR TITLE
Set berkshelf to use 2.x branch. Fixes #50

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -3,6 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'berkshelf'
+gem 'berkshelf', '~> 2.0.18'
 gem 'gusteau'
 gem 'serverspec', '~> 0.6.30'


### PR DESCRIPTION
The current version of gusteau does not work with berkshelf 3.x, so forcing it to use the berkshelf 2.x branch resolves any install incompatibilities when performing a converge.
